### PR TITLE
feat: add OLED sleep settings and management to save the display from burn-in and pinned espressif32 version

### DIFF
--- a/data/setup.html
+++ b/data/setup.html
@@ -69,6 +69,24 @@
                     </select>
                 </div>
             </div>
+
+            <div class="fm-card">
+                <h2>Display Settings</h2>
+
+                <div class="fm-form-group" style="margin-top: 1rem;">
+                    <label class="fm-label" for="sleepTimeoutSelect">OLED Sleep Timeout</label>
+                    <select id="sleepTimeoutSelect" class="fm-input">
+                        <option value="0">Disabled (always on)</option>
+                        <option value="30">30 seconds</option>
+                        <option value="60">1 minute</option>
+                        <option value="120">2 minutes</option>
+                        <option value="300">5 minutes</option>
+                        <option value="600">10 minutes</option>
+                    </select>
+                    <p style="font-size: 0.8rem; margin-top: 0.5rem;">Display wakes automatically on weight change or NFC tag read.</p>
+                </div>
+                <div id="sleepStatusMessage" style="margin-top: 0.5rem;"></div>
+            </div>
         </main>
     </div>
 
@@ -103,6 +121,43 @@
                 }
             })
             .catch(error => console.error('Error saving language:', error));
+        });
+
+        // Display sleep timeout setting
+        fetch('/api/display')
+            .then(response => response.json())
+            .then(data => {
+                const sel = document.getElementById('sleepTimeoutSelect');
+                const val = String(data.sleepTimeout);
+                // Select closest matching option
+                let matched = false;
+                for (let i = 0; i < sel.options.length; i++) {
+                    if (sel.options[i].value === val) { sel.value = val; matched = true; break; }
+                }
+                if (!matched) sel.value = '0';
+            })
+            .catch(error => console.error('Error fetching display settings:', error));
+
+        document.getElementById('sleepTimeoutSelect').addEventListener('change', function() {
+            const msg = document.getElementById('sleepStatusMessage');
+            fetch('/api/display', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ sleepTimeout: parseInt(this.value) })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    msg.textContent = 'Saved.';
+                    msg.style.color = 'var(--success-text)';
+                    setTimeout(() => { msg.textContent = ''; }, 2000);
+                }
+            })
+            .catch(error => {
+                msg.textContent = 'Error saving setting.';
+                msg.style.color = 'var(--error-text)';
+                console.error('Error saving display settings:', error);
+            });
         });
 
         document.getElementById('registerBtn').addEventListener('click', () => {

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ to_old_version = "3.0.9"
 
 ##
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@^6.0.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -42,7 +42,9 @@ String filamanToken = "";
 bool filamanRegistered = false;
 // ***** API
 
-// ***** Bambu Auto Set Spool
+// ***** Display Sleep
+uint16_t oledSleepTimeout = 60; // Default 60 seconds (0 = disabled)
+// ***** Display Sleep
 
 // ***** Task Prios
 uint8_t rfidTaskCore = 1;

--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,7 @@
 
 #define NVS_NAMESPACE_SETTINGS             "settings"
 #define NVS_KEY_LANGUAGE                    "language"
+#define NVS_KEY_OLED_SLEEP                  "oled_sleep"
 #define SCALE_DEFAULT_CALIBRATION_VALUE     430.0f;
 
 #define OLED_RESET                          -1      // Reset pin # (or -1 if sharing Arduino reset pin)
@@ -70,4 +71,5 @@ extern uint8_t scaleTaskCore;
 extern uint8_t scaleTaskPrio;
 
 extern uint16_t defaultScaleCalibrationValue;
+extern uint16_t oledSleepTimeout;
 #endif

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -5,6 +5,7 @@
 #include "main.h"
 #include <cstring>
 #include "lang.h"
+#include <Preferences.h>
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
@@ -15,6 +16,60 @@ bool iconToggle = false;
 static DisplayPriority currentPriority = DISPLAY_PRIORITY_NONE;
 static unsigned long prioritySetTime = 0;
 static unsigned long priorityMinDuration = 0;
+
+// Display sleep management
+static bool oledAsleep = false;
+static unsigned long lastActivityMillis = 0;
+
+void oledWake() {
+    if (oledAsleep) {
+        display.ssd1306_command(SSD1306_DISPLAYON);
+        oledAsleep = false;
+    }
+    lastActivityMillis = millis();
+}
+
+void oledSleep() {
+    if (!oledAsleep) {
+        display.ssd1306_command(SSD1306_DISPLAYOFF);
+        oledAsleep = true;
+    }
+}
+
+void oledResetActivityTimer() {
+    lastActivityMillis = millis();
+    if (oledAsleep) {
+        oledWake();
+    }
+}
+
+void oledCheckSleep() {
+    if (oledSleepTimeout == 0 || oledAsleep) return;
+    if (millis() - lastActivityMillis >= (unsigned long)oledSleepTimeout * 1000UL) {
+        oledSleep();
+    }
+}
+
+bool isOledAsleep() {
+    return oledAsleep;
+}
+
+void loadOledSleepTimeout() {
+    Preferences preferences;
+    preferences.begin(NVS_NAMESPACE_SETTINGS, true);
+    oledSleepTimeout = preferences.getUShort(NVS_KEY_OLED_SLEEP, 60);
+    preferences.end();
+    Serial.print("OLED sleep timeout loaded: ");
+    Serial.println(oledSleepTimeout);
+}
+
+void saveOledSleepTimeout(uint16_t timeoutSecs) {
+    oledSleepTimeout = timeoutSecs;
+    Preferences preferences;
+    preferences.begin(NVS_NAMESPACE_SETTINGS, false);
+    preferences.putUShort(NVS_KEY_OLED_SLEEP, timeoutSecs);
+    preferences.end();
+}
 
 bool oledCanUpdate(DisplayPriority newPriority) {
     if (currentPriority == DISPLAY_PRIORITY_NONE) return true;
@@ -55,6 +110,9 @@ void setupDisplay() {
     display.setTextColor(WHITE);
     display.clearDisplay();
 
+    // Load sleep timeout from NVS
+    loadOledSleepTimeout();
+    lastActivityMillis = millis();
 
     oledShowTopRow();
     oledShowProgressBar(0, 7, DISPLAY_BOOT_TEXT, tr(STR_DISPLAY_INIT));

--- a/src/display.h
+++ b/src/display.h
@@ -30,6 +30,15 @@ void oledcleardata();
 int oled_center_h(const String &text);
 int oled_center_v(const String &text);
 
+// Display sleep management
+void oledWake();
+void oledSleep();
+void oledResetActivityTimer();
+void oledCheckSleep();
+bool isOledAsleep();
+void loadOledSleepTimeout();
+void saveOledSleepTimeout(uint16_t timeoutSecs);
+
 void oledShowProgressBar(const uint8_t step, const uint8_t numSteps, const char* largeText, const char* statusMessage);
 
 void oledShowWeight(int16_t weight);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,7 @@ void loop() {
   {
     lastButtonPress = currentMillis;
     scaleTareRequest = true;
+    oledResetActivityTimer(); // Wake display on touch press
   }
 
   // Überprüfe regelmäßig die WLAN-Verbindung
@@ -139,6 +140,7 @@ void loop() {
   if (intervalElapsed(currentMillis, lastTopRowUpdateTime, DISPLAY_UPDATE_INTERVAL)) 
   {
     oledShowTopRow();
+    oledCheckSleep(); // Put display to sleep if timeout elapsed
     // Clean up dead websocket clients periodically instead of on connect
     if(currentMillis % 10000 < 50) ws.cleanupClients(); 
   }

--- a/src/nfc.cpp
+++ b/src/nfc.cpp
@@ -2050,6 +2050,9 @@ void scanRfidTask(void * parameter) {
         // Set the current tag as not processed
         tagProcessed = false;
 
+        // Wake display when a tag is detected
+        oledResetActivityTimer();
+
         // Display some basic information about the card
         Serial.println("Found an ISO14443A card");
 

--- a/src/scale.cpp
+++ b/src/scale.cpp
@@ -196,6 +196,7 @@ void scale_loop(void * parameter) {
         // Update global weight variable only if it changed significantly (for API actions)
         if (stabilizedWeight != weight) {
           weight = stabilizedWeight;
+          oledResetActivityTimer(); // Wake display on weight change
         }
         
         // Prüfen ob die Waage korrekt genullt ist

--- a/src/website.cpp
+++ b/src/website.cpp
@@ -272,6 +272,31 @@ void setupWebserver(AsyncWebServer &server) {
         request->send(200, "application/json", "{\"success\": true}");
     });
 
+    // Display Settings API
+    server.on("/api/display", HTTP_GET, [](AsyncWebServerRequest *request){
+        JsonDocument doc;
+        doc["sleepTimeout"] = oledSleepTimeout;
+        String response;
+        serializeJson(doc, response);
+        request->send(200, "application/json", response);
+    });
+
+    server.on("/api/display", HTTP_POST, [](AsyncWebServerRequest *request){}, NULL, [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total){
+        JsonDocument doc;
+        DeserializationError error = deserializeJson(doc, (const uint8_t*)data, len);
+        if (error) {
+            request->send(400, "application/json", "{\"success\": false, \"error\": \"Invalid JSON\"}");
+            return;
+        }
+        if (!doc["sleepTimeout"].is<int>()) {
+            request->send(400, "application/json", "{\"success\": false, \"error\": \"Missing sleepTimeout\"}");
+            return;
+        }
+        uint16_t timeout = (uint16_t)constrain((int)doc["sleepTimeout"], 0, 3600);
+        saveOledSleepTimeout(timeout);
+        request->send(200, "application/json", "{\"success\": true}");
+    });
+
     server.on("/reboot", HTTP_GET, [](AsyncWebServerRequest *request){
         request->send(200, "text/plain", "Rebooting...");
         delay(500);


### PR DESCRIPTION
Added display sleep as i leave the scales connected and dont want the oled to burn on.

Additionally i had issues building without pinning the espressif32 version to v6

Here is what the new UI change looks like

<img width="1445" height="666" alt="image" src="https://github.com/user-attachments/assets/5caae516-a5f4-4046-9847-f4e8e0ddc1d6" />
