### PR TITLE
fix(nfc): pulse PN532 RSTPDN before begin()

### DIFF
--- a/src/nfc.cpp
+++ b/src/nfc.cpp
@@ -532,6 +532,11 @@ uint8_t ntag2xx_WriteNDEF(const char *payload) {
     Serial.println("1. Neuinitialisierung des PN532...");
 
     // Reinitialize the PN532
+    pinMode(PN532_RESET, OUTPUT);
+    digitalWrite(PN532_RESET, LOW);
+    delay(50);
+    digitalWrite(PN532_RESET, HIGH);
+    delay(200);
     nfc.begin();
     vTaskDelay(pdMS_TO_TICKS(500)); // Give it time to initialize
 
@@ -2228,7 +2233,12 @@ void scanRfidTask(void * parameter) {
 void startNfc() {
   nfcRequestMutex = xSemaphoreCreateMutex();
   oledShowProgressBar(4, NUM_SETUP_STEPS, DISPLAY_BOOT_TEXT, tr(STR_NFC_INIT));
-  nfc.begin();                                           // Beginne Kommunikation mit RFID Leser
+  pinMode(PN532_RESET, OUTPUT);
+  digitalWrite(PN532_RESET, LOW);
+  delay(50);
+  digitalWrite(PN532_RESET, HIGH);
+  delay(200);
+  nfc.begin();                                        // Beginne Kommunikation mit RFID Leser
 
   delay(1000);
   unsigned long versiondata = nfc.getFirmwareVersion();  // Lese Versionsnummer der Firmware aus


### PR DESCRIPTION
Adafruit_PN532::begin() drives the reset line too briefly for this
module to leave powerdown. The chip ACKs its I2C address at 0x24 but
getFirmwareVersion() returns 0, so startNfc() reported 'Kann kein RFID
Board finden' and the read loop logged i2cRead Error 263 once a second.

Hold RSTPDN low 50ms then high 200ms before begin(). Applied to both
startNfc() and the interface recovery path.

Verified on ESP32-D0WD-V3 + PN532 v1.6: firmware reads 0x32010607 and
Mifare Classic UIDs are detected.
